### PR TITLE
Add JSON manifest

### DIFF
--- a/io.github.fabrialberio.pinapp.json
+++ b/io.github.fabrialberio.pinapp.json
@@ -1,0 +1,40 @@
+{
+    "app-id" : "io.github.fabrialberio.pinapp",
+    "runtime" : "org.gnome.Platform",
+    "runtime-version" : "43",
+    "sdk" : "org.gnome.Sdk",
+    "command" : "pinapp",
+    "finish-args" : [
+        "--share=ipc",
+        "--socket=fallback-x11",
+        "--device=dri",
+        "--socket=wayland",
+        "--filesystem=xdg-data/applications:rw",
+        "--filesystem=xdg-data/flatpak:ro",
+        "--filesystem=/var/lib/flatpak:ro"
+    ],
+    "cleanup" : [
+        "/include",
+        "/lib/pkgconfig",
+        "/man",
+        "/share/doc",
+        "/share/gtk-doc",
+        "/share/man",
+        "/share/pkgconfig",
+        "*.la",
+        "*.a"
+    ],
+    "modules" : [
+        {
+            "name" : "PinApp",
+            "builddir" : true,
+            "buildsystem" : "meson",
+            "sources" : [
+                {
+                    "type" : "dir",
+                    "path" : "."
+                }
+            ]
+        }
+    ]
+}


### PR DESCRIPTION
While `yml` manifests are supported by flatpak-builder, they seem to be unsupported by GNOME Builder unfortunately. I added `json` manifest that can be used there. It's identical to `yml` manifest, except for the sources: instead of building from specific commit in repository, it builds the app from current directory, allowing to test changes in one click.
I didn't touch `yml` file, only added `json`. I hope it will be useful, if not for you, then for other contributors who use GNOME Builder.