### PR TITLE
Use LC_CTYPE to detect language

### DIFF
--- a/src/desktop_entry.py
+++ b/src/desktop_entry.py
@@ -3,7 +3,7 @@ from pathlib import Path
 from typing import Callable
 
 from os import access, W_OK
-from locale import getlocale, LC_ALL
+from locale import getlocale, LC_CTYPE
 from configparser import ConfigParser, SectionProxy, Error as ConfigParserError
 
 
@@ -27,7 +27,7 @@ class LocaleString:
         return cls(lang, country, modifier)
 
     @classmethod
-    def current(cls, category = LC_ALL) -> 'LocaleString':
+    def current(cls, category = LC_CTYPE) -> 'LocaleString':
         return cls.parse(getlocale(category)[0])
 
 


### PR DESCRIPTION
Using LC_ALL causes problems when a user has mixed locale as shown in #19. en_US language and pt_BR formats cause LC_ALL to be en_BR, which is invalid locale, so it remains empty. As far as I know LC_CTYPE should always be the same as LANG, so it's safe to use it to detect language, and I tested that it works for both single and mixed locales.

Closes #19 