### PR TITLE
Appdata related patches

### DIFF
--- a/data/io.github.fabrialberio.pinapp.appdata.xml.in
+++ b/data/io.github.fabrialberio.pinapp.appdata.xml.in
@@ -8,6 +8,9 @@
 	<project_license>GPL-3.0-or-later</project_license>
 	<summary>Create and edit app shortcuts</summary>
     <developer_name translate="no">Fabrizio Alberio</developer_name>
+	<developer id="io.github.fabrialberio">
+		<name translate="no">Fabrizio Alberio</name>
+	</developer>
 	<description>
 		<p>PinApp is a simple application that lets you customize your app list.</p>
 		<p>Some of the possible uses are</p>

--- a/data/io.github.fabrialberio.pinapp.appdata.xml.in
+++ b/data/io.github.fabrialberio.pinapp.appdata.xml.in
@@ -3,11 +3,11 @@
 	<id>io.github.fabrialberio.pinapp</id>
 	<launchable type="desktop-id">io.github.fabrialberio.pinapp.desktop</launchable>
 	<translation type="gettext">pinapp</translation>
-	<name translatable="no">PinApp</name>
+	<name translate="no">PinApp</name>
 	<metadata_license>CC0-1.0</metadata_license>
 	<project_license>GPL-3.0-or-later</project_license>
 	<summary>Create and edit app shortcuts</summary>
-    <developer_name translatable="no">Fabrizio Alberio</developer_name>
+    <developer_name translate="no">Fabrizio Alberio</developer_name>
 	<description>
 		<p>PinApp is a simple application that lets you customize your app list.</p>
 		<p>Some of the possible uses are</p>
@@ -48,7 +48,7 @@
 	</recommends>
 	<releases>
 		<release version="1.3.0" date="2024-12-31">
-			<description translatable="no">
+			<description translate="no">
 				<p>What's changed</p>
 				<ul>
 					<li>@Alexmelman88 updated the Russian translation</li>
@@ -59,7 +59,7 @@
 			</description>
 		</release>
 		<release version="1.2.0" date="2022-09-04">
-			<description translatable="no">
+			<description translate="no">
 				<p>What's changed</p>
 				<ul>
 					<li>Implemented autosave</li>
@@ -82,7 +82,7 @@
 			</description>
 		</release>
 		<release version="1.1.7" date="2022-12-31">
-			<description translatable="no">
+			<description translate="no">
 				<p>What's changed</p>
 				<ul>
 					<li>Added russian translation thanks to @fsobolev</li>
@@ -100,7 +100,7 @@
 			</description>
 		</release>
 		<release version="1.1.6" date="2022-11-27">
-			<description translatable="no">
+			<description translate="no">
 				<p>What's changed</p>
 				<ul>
 					<li>Added functionality to search for apps by file content</li>
@@ -114,7 +114,7 @@
 			</description>
 		</release>
 		<release version="1.1.5" date="2022-10-22">
-			<description translatable="no">
+			<description translate="no">
 				<p>What's changed</p>
 				<ul>
 					<li>Added translation template</li>
@@ -129,7 +129,7 @@
 			</description>
 		</release>
 		<release version="1.1.4" date="2022-10-14">
-			<description translatable="no">
+			<description translate="no">
 				<p>What's changed</p>
 				<ul>
 					<li>More consinstent app icon behaviour for non-existing paths or names</li>
@@ -142,7 +142,7 @@
 			</description>
 		</release>
 		<release version="1.1.3" date="2022-10-14">
-			<description translatable="no">
+			<description translate="no">
 				<p>What's changed</p>
 				<ul>
 					<li>Changed appearance of missing icon to match system app list</li>
@@ -158,7 +158,7 @@
 			</description>
 		</release>
 		<release version="1.1.2" date="2022-10-09">
-			<description translatable="no">
+			<description translate="no">
 				<p>What's changed</p>
 				<ul>
 					<li>Better wording in various dialogs and buttons</li>
@@ -173,7 +173,7 @@
 			</description>
 		</release>
 		<release version="1.1.1" date="2022-10-02">
-			<description translatable="no">
+			<description translate="no">
 				<p>What's changed</p>
 				<ul>
 					<li>Simplified app navigation with Adw.ViewSwitcher</li>


### PR DESCRIPTION
### appdata: translate=no properties

It appears that the appstream project no longer supports
`translatable=no` properties, and gettext extract them as translatable.

I opened an issue to inform about the situation, but `translatable=no`
properties are not accepted by developers. You can find the issue
here: `https://github.com/ximion/appstream/issues/623

**Please test your script or string extraction process before merging this PR.**

> In MetaInfo files, each individual paragraph of a description
> (or enumerated entry) is translated individually, however,
> you can only exclude the complete block from being translated
> by adding `translate="no"` to the description element.

Source: https://freedesktop.org/software/appstream/docs/sect-Quickstart-Translation.html

### appdata: Add developer ID

Flathub requires a developer tag and developer ID. Also Appstream decided to use rdns structure for developer ID.

It allows reverse-dns IDs like sh.cozy, de.geigi or Fediverse handle (like @user@example.org)

> A developer tag with a name child tag must be present.
> Only one developer tag is allowed and the name tag also must be present only once in untranslated form.

```
<developer id="tld.vendor">
  <name>Developer name</name>
</developer>
```
Source: https://docs.flathub.org/docs/for-app-authors/metainfo-guidelines/#name-summary-and-developer-name

> The element should have a id property, containing a unique ID to identify the component developer / development team. It is recommended to use a reverse-DNS name, like org.gnome or io.github.ximion, or a Fediverse handle (like @user@example.org) as ID to achieve a higher chance of uniqueness.

Source: https://www.freedesktop.org/software/appstream/docs/chap-Metadata.html#tag-developer